### PR TITLE
Fix streaming validation dataset causing infinite loop

### DIFF
--- a/open_diloco/train_diloco_torch.py
+++ b/open_diloco/train_diloco_torch.py
@@ -210,7 +210,6 @@ def main(
             streaming=True,
             data_files={
                 "train": "en/c4-train.*.json.gz",
-                "validation": "en/c4-validation.00000-of-00008.json.gz",
             },
         )
     )
@@ -229,9 +228,18 @@ def main(
     train_dataloader = DataLoader(train_dataset, collate_fn=data_collator, batch_size=per_device_train_batch_size)
 
     if eval_steps is not None:
-        eval_dataset = tokenized_datasets["validation"]
+        # Load validation dataset without streaming to avoid infinite loop
+        eval_dataset_raw = load_dataset(
+            "allenai/c4",
+            "en",
+            streaming=False,
+            data_files={
+                "validation": "en/c4-validation.00000-of-00008.json.gz",
+            },
+        )
+        eval_tokenized = eval_dataset_raw.map(tokenize_function, batched=True, remove_columns=["text", "timestamp", "url"])
         eval_dataloader = DataLoader(
-            eval_dataset,
+            eval_tokenized["validation"],
             collate_fn=data_collator,
             batch_size=per_device_train_batch_size,
         )


### PR DESCRIPTION
Fixes #42

## Problem
In `train_diloco_torch.py`, the validation dataset was loaded as part of a streaming (`IterableDataset`) load. The `evaluate_model` function iterates over `eval_dataloader` with a `for` loop, which never terminates because streaming datasets have no `__len__` and never signal end-of-data.

## Fix
- Removed `validation` from the streaming `load_dataset` call (training only)
- Load the validation dataset separately with `streaming=False` only when `eval_steps is not None`
- Apply the same tokenization and collation to the non-streaming validation set

This keeps training efficient with streaming while ensuring validation has a finite, known length.