### PR TITLE
fix: pin hivemind>=1.1.11 for PyTorch 2.3+ compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ wandb>=0.16.4
 cyclopts>=2.6.1
 fsspec[gcs]>=2024.3.1
 torch==2.3.1
-hivemind @ git+https://github.com/learning-at-home/hivemind.git@213bff9
+hivemind>=1.1.11
 pydantic_config @ git+https://github.com/samsja/pydantic_config.git@8e19e05
 


### PR DESCRIPTION
Fixes #41

The old pinned hivemind commit imports `_refresh_per_optimizer_state` from `torch.cuda.amp.grad_scaler`, which was removed/renamed in PyTorch 2.3+.

hivemind 1.1.11+ includes a fix that checks the torch version and imports from the correct location (`torch.amp` for PyTorch >= 2.3.0).

Changes:
- Pin hivemind to `>=1.1.11` instead of a specific git commit that is incompatible with PyTorch 2.3+