### PR TITLE
Fix streaming validation infinite loop (#42)

### DIFF
--- a/open_diloco/train_diloco_torch.py
+++ b/open_diloco/train_diloco_torch.py
@@ -230,6 +230,10 @@ def main(
 
     if eval_steps is not None:
         eval_dataset = tokenized_datasets["validation"]
+        # Limit streaming validation to 1000 samples to avoid infinite loop
+        # (IterableDataset has no __len__, causing DataLoader to loop forever)
+        if hasattr(eval_dataset, "take"):
+            eval_dataset = eval_dataset.take(1000)
         eval_dataloader = DataLoader(
             eval_dataset,
             collate_fn=data_collator,


### PR DESCRIPTION
Fixes #42

**Problem:** In `train_diloco_torch.py`, the validation dataset is loaded with `streaming=True`, creating an `IterableDataset` that lacks `__len__`. The `DataLoader` iterates infinitely in `evaluate_model()`, never terminating.

**Solution:** Limit the streaming validation dataset to 1000 samples using `eval_dataset.take(1000)`. This caps evaluation to a reasonable sample size for perplexity testing while avoiding the infinite loop.

Uses `hasattr(eval_dataset, "take")` guard so the fix is safe for non-streaming datasets (e.g., when using `c4_tiny`).